### PR TITLE
Patch for windows file paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evidence-connector-js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evidence-connector-js",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@evidence-dev/db-commons": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evidence-connector-js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "src/index.js",
   "type": "module",
@@ -19,7 +19,9 @@
     "@evidence-dev/db-commons": "^1.0.5"
   },
   "evidence": {
-    "datasources": [ "js" ],
+    "datasources": [
+      "js"
+    ],
     "icon": "Javascript"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { EvidenceType } from "@evidence-dev/db-commons";
+import { pathToFileURL } from 'url';
 
 /**
  * @see https://docs.evidence.dev/plugins/create-source-plugin/#options-specification
@@ -22,8 +23,8 @@ export const getRunner = (options) => {
     // Check if the file is a JavaScript file
     if (queryPath.endsWith(".js")) {
       try {
-        // Dynamically import the JavaScript file
-        const module = await import(queryPath);
+        // Convert the file path to a file URL
+        const module = await import(pathToFileURL(queryPath).href);
 
         // Access the exported 'data' variable
         const data = module.data;


### PR DESCRIPTION
Fixes:

```bash
[ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```